### PR TITLE
Add a cvar to specify vote config file path

### DIFF
--- a/scripting/l4d2_config_vote.sp
+++ b/scripting/l4d2_config_vote.sp
@@ -6,8 +6,7 @@
 #include <l4d2_source_keyvalues>	// https://github.com/fdxx/l4d2_source_keyvalues
 #include <multicolors>
 
-#define VERSION "0.6"
-#define CFG_FILE "data/l4d2_config_vote.kv"
+#define VERSION "0.7"
 #define COMMAND_MAX_LENGTH 511
 
 #define TEAMFLAGS_SPEC	2
@@ -39,7 +38,7 @@ SourceKeyValues
 	g_kvSelect[MAXPLAYERS+1],
 	g_kvRoot;
 
-ConVar g_cvAdminTeamFlags, g_cvPrintMsg;
+ConVar g_cvVoteFilePath, g_cvAdminTeamFlags, g_cvPrintMsg;
 ConfigData g_cfgData[MAXPLAYERS+1];
 
 public Plugin myinfo = 
@@ -58,10 +57,16 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 public void OnPluginStart()
 {
 	CreateConVar("l4d2_config_vote_version", VERSION, "version", FCVAR_NOTIFY | FCVAR_DONTRECORD);
+	g_cvVoteFilePath = CreateConVar("l4d2_config_vote_path", "data/l4d2_config_vote.kv", "Vote config file path");
 	g_cvAdminTeamFlags = CreateConVar("l4d2_config_vote_adminteamflags", "1", "Admin bypass TeamFlags.");
 	g_cvPrintMsg = CreateConVar("l4d2_config_vote_printmsg", "1", "Whether print hint message to clients.");
+	g_cvVoteFilePath.AddChangeHook(OnCvarChanged);
+	// AutoExecConfig(true, "l4d2_config_vote");
+}
 
-	AutoExecConfig(true, "l4d2_config_vote");
+void OnCvarChanged(ConVar convar, const char[] oldValue, const char[] newValue)
+{
+	Init();
 }
 
 public void OnConfigsExecuted()
@@ -74,6 +79,7 @@ public void OnConfigsExecuted()
 	RegAdminCmdEx("sm_votecfg_reload", Cmd_Reload, ADMFLAG_ROOT, "Reload config file.");
 	RegConsoleCmdEx("sm_v", Cmd_Vote);
 	RegConsoleCmdEx("sm_vt", Cmd_Vote);
+	RegConsoleCmdEx("sm_vote", Cmd_Vote);
 	RegConsoleCmdEx("sm_votes", Cmd_Vote);
 }
 
@@ -380,7 +386,9 @@ void Init()
 		g_kvRoot.deleteThis();
 
 	char file[PLATFORM_MAX_PATH];
-	BuildPath(Path_SM, file, sizeof(file), CFG_FILE);
+	char g_sVoteFile[128];
+	GetConVarString(g_cvVoteFilePath, g_sVoteFile, sizeof(g_sVoteFile));
+	BuildPath(Path_SM, file, sizeof(file), g_sVoteFile);
 
 	g_kvRoot = SourceKeyValues("");
 	g_kvRoot.UsesEscapeSequences(true);

--- a/scripting/l4d2_config_vote.sp
+++ b/scripting/l4d2_config_vote.sp
@@ -57,7 +57,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 public void OnPluginStart()
 {
 	CreateConVar("l4d2_config_vote_version", VERSION, "version", FCVAR_NOTIFY | FCVAR_DONTRECORD);
-	g_cvVoteFilePath = CreateConVar("l4d2_config_vote_path", "data/l4d2_config_vote.kv", "Vote config file path");
+	g_cvVoteFilePath = CreateConVar("l4d2_config_vote_path", "data/l4d2_config_vote.kv", "Vote config file path.");
 	g_cvAdminTeamFlags = CreateConVar("l4d2_config_vote_adminteamflags", "1", "Admin bypass TeamFlags.");
 	g_cvPrintMsg = CreateConVar("l4d2_config_vote_printmsg", "1", "Whether print hint message to clients.");
 	g_cvVoteFilePath.AddChangeHook(OnCvarChanged);

--- a/scripting/l4d2_config_vote.sp
+++ b/scripting/l4d2_config_vote.sp
@@ -79,7 +79,6 @@ public void OnConfigsExecuted()
 	RegAdminCmdEx("sm_votecfg_reload", Cmd_Reload, ADMFLAG_ROOT, "Reload config file.");
 	RegConsoleCmdEx("sm_v", Cmd_Vote);
 	RegConsoleCmdEx("sm_vt", Cmd_Vote);
-	RegConsoleCmdEx("sm_vote", Cmd_Vote);
 	RegConsoleCmdEx("sm_votes", Cmd_Vote);
 }
 
@@ -386,9 +385,9 @@ void Init()
 		g_kvRoot.deleteThis();
 
 	char file[PLATFORM_MAX_PATH];
-	char g_sVoteFile[128];
-	GetConVarString(g_cvVoteFilePath, g_sVoteFile, sizeof(g_sVoteFile));
-	BuildPath(Path_SM, file, sizeof(file), g_sVoteFile);
+	char voteFilePath[PLATFORM_MAX_PATH];
+	g_cvVoteFilePath.GetString(voteFilePath, sizeof(voteFilePath));
+	BuildPath(Path_SM, file, sizeof(file), voteFilePath);
 
 	g_kvRoot = SourceKeyValues("");
 	g_kvRoot.UsesEscapeSequences(true);


### PR DESCRIPTION
[Add a cvar to specify vote config file path](https://github.com/Hatsune-Imagine/l4d2_config_vote/commit/5e3f47ed57b7c143ac4d51c8266ac1cd5d5cbeb3)

So now we can edit many vote config files, and show different vote menu in different match modes.