### PR TITLE
Update the logic of judging vote result when vote ends

### DIFF
--- a/scripting/l4d2_config_vote.sp
+++ b/scripting/l4d2_config_vote.sp
@@ -6,7 +6,7 @@
 #include <l4d2_source_keyvalues>	// https://github.com/fdxx/l4d2_source_keyvalues
 #include <multicolors>
 
-#define VERSION "0.7"
+#define VERSION "0.8"
 #define COMMAND_MAX_LENGTH 511
 
 #define TEAMFLAGS_SPEC	2
@@ -121,7 +121,7 @@ void ShowMenu(int client, SourceKeyValues kv, bool bBackButton = true)
 	}
 
 	menu.ExitBackButton = bBackButton;
-	menu.Display(client, 20);
+	menu.Display(client, MENU_TIME_FOREVER);
 }
 
 int MenuHandlerCB(Menu menu, MenuAction action, int client, int itemNum)

--- a/scripting/l4d2_config_vote.sp
+++ b/scripting/l4d2_config_vote.sp
@@ -237,7 +237,7 @@ void Vote_Handler(L4D2NativeVote vote, VoteAction action, int param1, int param2
 		}
 		case VoteAction_End:
 		{
-			if (vote.YesCount > vote.PlayerCount/2)
+			if (vote.YesCount > vote.NoCount)
 			{
 				vote.SetPass("加载中...");
 


### PR DESCRIPTION
1. 将菜单显示时间改为 `MENU_TIME_FOREVER` (0)，当菜单内容过多时，能给用户足够的时间翻找需要的选项。

2. 将判断投票通过的逻辑，
原本的逻辑为 `vote.YesCount > playerCount / 2`
现修改为 `vote.YesCount > vote.NoCount`

因为原本的逻辑会出现以下情况：
当服务器内有4人时，有人发起投票
1票同意，剩余3人均弃票（未投同意或反对）
|✓|   |   |   |
此时，仍然会判定投票不通过。

当服务器有8人时，有人发起投票
即使有4人投票同意，但另外4人不投票时
|✓|✓|✓|✓|   |   |   |   |
此时，仍然会判定投票不通过。

此次修改改进了此情况，改为与游戏原生投票判定通过逻辑一致。