### PR TITLE
Happy New Feature!

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Generate a vote menu from a configuration file and vote it.
 - `ExternalVote`：Call vote command provided by other plugin after menu selection. Valid item for this type：**MenuTeamFlags**, **Command**.  
 - `CheatCommand`：Execute server cheat command after vote is passed.  
   
+### Description
+Info displayed after initiating a vote.  
+  
+### Command
+Command executed after the vote is passed.  
+  
 ### SelectType (Optional)
 If this property is set on one node, then all of it's first level sub nodes will show a selected icon.  
 - `Single`：If one config's vote is passed, this node's icon will be set to selected, and all the other same level nodes' icon will be set to unselected.  
@@ -91,9 +97,3 @@ Whether to enable admin one vote to passed. default value: 1 (enable).
   
 ### AdminOneVoteAgainst (Optional)
 Whether to enable admin one vote to against. default value: 1 (enable).  
-  
-### Description
-Info displayed after initiating a vote.  
-  
-### Command
-Command executed after the vote is passed.  

--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@ Generate a vote menu from a configuration file and vote it.
 - [l4d2_source_keyvalues](https://github.com/fdxx/l4d2_source_keyvalues)  
   
 ## Cmd and Cvar
+- `l4d2_config_vote_path`: Console Variables, Menu vote config file path.  
+- `l4d2_config_vote_menucustomflags`: Console Variables, Menu custom rules of showing.  
 - `l4d2_config_vote_adminteamflags`: Console Variables, Admin bypass `*TeamFlags`.  
+- `l4d2_config_vote_printmsg`: Console Variables, Whether print hint message to clients.  
+- `l4d2_config_vote_passmode`: Console Variables, Method of judging vote pass. 0=Vote Yes count > Vote No count. 1=Vote Yes count > Half of players count.  
+- `l4d2_config_vote_icon_selected`: Console Variables, Selected Icon (Default: `[√]`).  
+- `l4d2_config_vote_icon_unselected`: Console Variables, Unselected Icon (Default: `[  ]`).  
 - `sm_votecfg_reload`: Console Commands (admin), Reload config file.  
+- `sm_v`: Console Commands, Open vote menu.  
+- `sm_vt`: Console Commands, Open vote menu.  
 - `sm_votes`: Console Commands, Open vote menu.  
   
 ## Config file
@@ -44,7 +52,7 @@ Specifying the cvar value datatype.
 - `string`：Indicate the cvar value is a string type.  
   
 ### CvarMatch (Optional)
-This property is valid only when **parent level** node's SelectType is specified to `CvarTracking`, and **parent level** node's CvarName and CvarType is specified correctly.  
+This property is valid only when **parent level** node's SelectType is specified to `CvarTracking`, and **parent level** node's CvarName and CvarType are specified correctly.  
 Specifying the voting config value, which matches the specified cvar value, used to show a selected icon.  
   
 ### PluginMatch (Optional)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Generate a vote menu from a configuration file and vote it.
 ## Require
 - L4D2 dedicated server
 - SourceMod 1.11
+- [left4dhooks](https://github.com/SilvDev/Left4DHooks)
 - [l4d2_nativevote](https://github.com/fdxx/l4d2_nativevote)
 - [l4d2_source_keyvalues](https://github.com/fdxx/l4d2_source_keyvalues)
 
@@ -19,6 +20,27 @@ Generate a vote menu from a configuration file and vote it.
 - `ClientCommand`：Execute client command after the vote is passed.
 - `ExternalVote`：Call vote command provided by other plugin after menu selection. Valid item for this type：**MenuTeamFlags**, **Command**.
 - `CheatCommand`：Execute server cheat command after vote is passed.
+
+### MenuCustomFlags (Optional)
+Whether clients can see the menu and initiate a vote, based on custom rules. default value: "\<Empty String\>" (no limits).
+#### Description:
+The value of `MenuCustomFlags` in the config menu can be set to a comma separated string. For example: "custom1", or "custom1,custom2".
+The value of the plugin cvar `l4d2_config_vote_menucustomflags` can also be set to a comma separated string. For example: "custom1", or "custom1,custom2".
+**If the `MenuCustomFlags` value is "<Empty String> (Not Configured)", then there will be no limits.**
+**If the `MenuCustomFlags` value is configured, then only if the `MenuCustomFlags` and the `l4d2_config_vote_menucustomflags` have some elements in common (the intersection of the `MenuCustomFlags` the `l4d2_config_vote_menucustomflags` is not empty), this config in the menu can be shown to clients.**
+> Example:
+>     1. `MenuCustomFlags`: "<Empty String> (Not Configured)", no matter what the cvar `l4d2_config_vote_menucustomflags` value is. ==> Clients **can see** this vote config in the menu.
+>     2. `MenuCustomFlags`: "1", `l4d2_config_vote_menucustomflags`: "1". ==> Clients **can see** this vote config in the menu.
+>     3. `MenuCustomFlags`: "2", `l4d2_config_vote_menucustomflags`: "1". ==> Clients **can not see** this vote config in the menu.
+>     4. `MenuCustomFlags`: "1", `l4d2_config_vote_menucustomflags`: "1,2". ==> Clients **can see** this vote config in the menu.
+>     5. `MenuCustomFlags`: "2", `l4d2_config_vote_menucustomflags`: "1,2". ==> Clients **can see** this vote config in the menu.
+>     6. `MenuCustomFlags`: "1,2", `l4d2_config_vote_menucustomflags`: "1". ==> Clients **can see** this vote config in the menu.
+>     7. `MenuCustomFlags`: "1,2", `l4d2_config_vote_menucustomflags`: "2". ==> Clients **can see** this vote config in the menu.
+>     8. `MenuCustomFlags`: "1,2", `l4d2_config_vote_menucustomflags`: "1,2". ==> Clients **can see** this vote config in the menu.
+
+### MenuModeFlags (Optional)
+Whether clients can see the menu and initiate a vote in these gamemodes (based on). coop=1, realism=2, versus=4, survival=8, scavenge=16, default value: 31 (all gamemodes).
+*Note: Mutations are also based on these fundamental gamemodes.*
 
 ### MenuTeamFlags (Optional)
 Which clients can see the menu and initiate a vote. spectator=2, survivors=4, infected=8, default value: 14 (all teams).

--- a/README.md
+++ b/README.md
@@ -1,86 +1,91 @@
 ## About
-Generate a vote menu from a configuration file and vote it.
-
+Generate a vote menu from a configuration file and vote it.  
+  
 ## Require
-- L4D2 dedicated server
-- SourceMod 1.11
-- [left4dhooks](https://github.com/SilvDev/Left4DHooks)
-- [l4d2_nativevote](https://github.com/fdxx/l4d2_nativevote)
-- [l4d2_source_keyvalues](https://github.com/fdxx/l4d2_source_keyvalues)
-
+- L4D2 dedicated server  
+- SourceMod 1.11  
+- [left4dhooks](https://github.com/SilvDev/Left4DHooks)  
+- [l4d2_nativevote](https://github.com/fdxx/l4d2_nativevote)  
+- [l4d2_source_keyvalues](https://github.com/fdxx/l4d2_source_keyvalues)  
+  
 ## Cmd and Cvar
-- `l4d2_config_vote_adminteamflags`: Console Variables, Admin bypass `*TeamFlags`.
-- `sm_votecfg_reload`: Console Commands (admin), Reload config file.
-- `sm_votes`: Console Commands, Open vote menu.
-
+- `l4d2_config_vote_adminteamflags`: Console Variables, Admin bypass `*TeamFlags`.  
+- `sm_votecfg_reload`: Console Commands (admin), Reload config file.  
+- `sm_votes`: Console Commands, Open vote menu.  
+  
 ## Config file
-
+  
 ### Type
-- `ServerCommand`：Execute server command or admin command after vote is passed.
-- `ClientCommand`：Execute client command after the vote is passed.
-- `ExternalVote`：Call vote command provided by other plugin after menu selection. Valid item for this type：**MenuTeamFlags**, **Command**.
-- `CheatCommand`：Execute server cheat command after vote is passed.
-
+- `ServerCommand`：Execute server command or admin command after vote is passed.  
+- `ClientCommand`：Execute client command after the vote is passed.  
+- `ExternalVote`：Call vote command provided by other plugin after menu selection. Valid item for this type：**MenuTeamFlags**, **Command**.  
+- `CheatCommand`：Execute server cheat command after vote is passed.  
+  
 ### SelectType (Optional)
-If this property is set on one node, then all of it's first level sub nodes will show a selected icon.
-- `Single`：If one config's vote is passed, this node's icon will be set to selected, and all the other same level nodes' icon will be set to unselected.
-- `Multiple`：If one config's vote is passed, this node's icon will be set to it's opposite.
-- `CvarTracking`：Whether showing the selected icon depends on a specified cvar value.
-
+If this property is set on one node, then all of it's first level sub nodes will show a selected icon.  
+- `Single`：If one config's vote is passed, this node's icon will be set to selected, and all the other same level nodes' icon will be set to unselected.  
+- `Multiple`：If one config's vote is passed, this node's icon will be set to it's opposite.  
+- `CvarTracking`：Whether showing the selected icon depends on a specified cvar value.  
+- `PluginTracking`：Whether showing the selected icon depends on whether a specified plugin is loaded.  
+  
 ### Selected (Optional)
-This property is valid only when **parent level** node's SelectType is specified to `Single` or `Multiple`.
-Marking this node as default selected.
-
+This property is valid only when **parent level** node's SelectType is specified to `Single` or `Multiple`.  
+Marking this node as default selected.  
+  
 ### CvarName (Optional)
-This property is valid only when **this level** node's SelectType is specified to `CvarTracking`.
-Specifying the cvar name to track.
-
+This property is valid only when **this level** node's SelectType is specified to `CvarTracking`.  
+Specifying the cvar name to track.  
+  
 ### CvarType (Optional)
-This property is valid only when **this level** node's SelectType is specified to `CvarTracking`.
-Specifying the cvar value datatype.
-- `int`：Indicate the cvar value is a int type.
-- `float`：Indicate the cvar value is a float type.
-- `string`：Indicate the cvar value is a string type.
-
+This property is valid only when **this level** node's SelectType is specified to `CvarTracking`.  
+Specifying the cvar value datatype.  
+- `int`：Indicate the cvar value is a int type.  
+- `float`：Indicate the cvar value is a float type.  
+- `string`：Indicate the cvar value is a string type.  
+  
 ### CvarMatch (Optional)
-This property is valid only when **parent level** node's SelectType is specified to `CvarTracking`, and **parent level** node's CvarName and CvarType is specified correctly.
-Specifying the value of this vote config, matching the specified cvar value.
-
+This property is valid only when **parent level** node's SelectType is specified to `CvarTracking`, and **parent level** node's CvarName and CvarType is specified correctly.  
+Specifying the voting config value, which matches the specified cvar value, used to show a selected icon.  
+  
+### PluginMatch (Optional)
+This property is valid only when **parent level** node's SelectType is specified to `PluginTracking`.  
+Specifying the voting config to load/unload the specified plugin, which matches the specified plugin name, used to show a selected icon.  
+  
 ### MenuCustomFlags (Optional)
-Whether clients can see the menu and initiate a vote, based on custom rules. default value: "\<Empty String\>" (no limits).
-#### Description:
-The value of `MenuCustomFlags` in the config menu can be set to a comma separated string. For example: "custom1", or "custom1,custom2".
-The value of the plugin cvar `l4d2_config_vote_menucustomflags` can also be set to a comma separated string. For example: "custom1", or "custom1,custom2".
-**If the `MenuCustomFlags` value is "<Empty String> (Not Configured)", then there will be no limits.**
-**If the `MenuCustomFlags` value is configured, then only if the `MenuCustomFlags` and the `l4d2_config_vote_menucustomflags` have some elements in common (the intersection of the `MenuCustomFlags` the `l4d2_config_vote_menucustomflags` is not empty), this config in the menu can be shown to clients.**
-> Example:
->     1. `MenuCustomFlags`: "<Empty String> (Not Configured)", no matter what the cvar `l4d2_config_vote_menucustomflags` value is. ==> Clients **can see** this vote config in the menu.
->     2. `MenuCustomFlags`: "1", `l4d2_config_vote_menucustomflags`: "1". ==> Clients **can see** this vote config in the menu.
->     3. `MenuCustomFlags`: "2", `l4d2_config_vote_menucustomflags`: "1". ==> Clients **can not see** this vote config in the menu.
->     4. `MenuCustomFlags`: "1", `l4d2_config_vote_menucustomflags`: "1,2". ==> Clients **can see** this vote config in the menu.
->     5. `MenuCustomFlags`: "2", `l4d2_config_vote_menucustomflags`: "1,2". ==> Clients **can see** this vote config in the menu.
->     6. `MenuCustomFlags`: "1,2", `l4d2_config_vote_menucustomflags`: "1". ==> Clients **can see** this vote config in the menu.
->     7. `MenuCustomFlags`: "1,2", `l4d2_config_vote_menucustomflags`: "2". ==> Clients **can see** this vote config in the menu.
->     8. `MenuCustomFlags`: "1,2", `l4d2_config_vote_menucustomflags`: "1,2". ==> Clients **can see** this vote config in the menu.
-
+Whether clients can see the menu and initiate a vote, based on custom rules. default value: "&lt;Empty String&gt;" (no limits).  
+#### Description
+The value of `MenuCustomFlags` in the config menu can be set to a comma separated string. For example: "custom1", or "custom1,custom2".  
+The value of the plugin cvar `l4d2_config_vote_menucustomflags` can also be set to a comma separated string. For example: "custom1", or "custom1,custom2".  
+**If the `MenuCustomFlags` value is "&lt;Empty String&gt; (Not Configured)", then there will be no limits.**  
+**If the `MenuCustomFlags` value is configured, then only if the `MenuCustomFlags` and the `l4d2_config_vote_menucustomflags` have some elements in common (the intersection of the `MenuCustomFlags` and the `l4d2_config_vote_menucustomflags` is not empty), this config in the menu can be shown to clients.**  
+> Example:  
+>     1. `MenuCustomFlags`: "(Not Configured)", no matter what the cvar `l4d2_config_vote_menucustomflags` value is. =&gt; Clients **can see** this vote config in menu.  
+>     2. `MenuCustomFlags`: "1", `l4d2_config_vote_menucustomflags`: "1". =&gt; Clients **can see** this vote config in menu.  
+>     3. `MenuCustomFlags`: "2", `l4d2_config_vote_menucustomflags`: "1". =&gt; Clients **can not see** this vote config in menu.  
+>     4. `MenuCustomFlags`: "1,2", `l4d2_config_vote_menucustomflags`: "1". =&gt; Clients **can see** this vote config in menu.  
+>     5. `MenuCustomFlags`: "1,2", `l4d2_config_vote_menucustomflags`: "3". =&gt; Clients **can not see** this vote config in menu.  
+>     6. `MenuCustomFlags`: "1", `l4d2_config_vote_menucustomflags`: "1,2". =&gt; Clients **can see** this vote config in menu.  
+>     7. `MenuCustomFlags`: "3", `l4d2_config_vote_menucustomflags`: "1,2". =&gt; Clients **can not see** this vote config in menu.  
+>     8. `MenuCustomFlags`: "1,2", `l4d2_config_vote_menucustomflags`: "2,3". =&gt; Clients **can see** this vote config in menu.  
+  
 ### MenuModeFlags (Optional)
-Whether clients can see the menu and initiate a vote in these gamemodes (based on). coop=1, realism=2, versus=4, survival=8, scavenge=16, default value: 31 (all gamemodes).
-*Note: Mutations are also based on these fundamental gamemodes.*
-
+Whether clients can see the menu and initiate a vote in these gamemodes (based on). coop=1, realism=2, versus=4, survival=8, scavenge=16, default value: 31 (all gamemodes).  
+*Note: Mutations are also based on these fundamental gamemodes.*  
+  
 ### MenuTeamFlags (Optional)
-Which clients can see the menu and initiate a vote. spectator=2, survivors=4, infected=8, default value: 14 (all teams).
-
+Which clients can see the menu and initiate a vote. spectator=2, survivors=4, infected=8, default value: 14 (all teams).  
+  
 ### VoteTeamFlags (Optional)
-Which clients can vote. spectator=2, survivors=4, infected=8, default value: 14 (all teams).
-
+Which clients can vote. spectator=2, survivors=4, infected=8, default value: 14 (all teams).  
+  
 ### AdminOneVotePassed (Optional)
-Whether to enable admin one vote to passed. default value: 1 (enable).
-
+Whether to enable admin one vote to passed. default value: 1 (enable).  
+  
 ### AdminOneVoteAgainst (Optional)
-Whether to enable admin one vote to against. default value: 1 (enable).
-
+Whether to enable admin one vote to against. default value: 1 (enable).  
+  
 ### Description
-Info displayed after initiating a vote.
-
+Info displayed after initiating a vote.  
+  
 ### Command
-Command executed after the vote is passed.
+Command executed after the vote is passed.  

--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@ Generate a vote menu from a configuration file and vote it.
 - `ExternalVote`：Call vote command provided by other plugin after menu selection. Valid item for this type：**MenuTeamFlags**, **Command**.
 - `CheatCommand`：Execute server cheat command after vote is passed.
 
+### SelectType (Optional)
+If this property is set on one node, then all of it's first level sub nodes will show a selected icon.
+- `Single`：If one config's vote is passed, this node's icon will be set to selected, and all the other same level nodes' icon will be set to unselected.
+- `Multiple`：If one config's vote is passed, this node's icon will be set to it's opposite.
+- `CvarTracking`：Whether showing the selected icon depends on a specified cvar value.
+
+### Selected (Optional)
+This property is valid only when **parent level** node's SelectType is specified to `Single` or `Multiple`.
+Marking this node as default selected.
+
+### CvarName (Optional)
+This property is valid only when **this level** node's SelectType is specified to `CvarTracking`.
+Specifying the cvar name to track.
+
+### CvarType (Optional)
+This property is valid only when **this level** node's SelectType is specified to `CvarTracking`.
+Specifying the cvar value datatype.
+- `int`：Indicate the cvar value is a int type.
+- `float`：Indicate the cvar value is a float type.
+- `string`：Indicate the cvar value is a string type.
+
+### CvarMatch (Optional)
+This property is valid only when **parent level** node's SelectType is specified to `CvarTracking`, and **parent level** node's CvarName and CvarType is specified correctly.
+Specifying the value of this vote config, matching the specified cvar value.
+
 ### MenuCustomFlags (Optional)
 Whether clients can see the menu and initiate a vote, based on custom rules. default value: "\<Empty String\>" (no limits).
 #### Description:

--- a/data/l4d2_config_vote.kv
+++ b/data/l4d2_config_vote.kv
@@ -567,6 +567,369 @@
 				"Command"				"exec vote/kill_si_restore_health_off.cfg"
 			}
 		}
+
+		"特感数量"
+		{
+			"SelectType"	"CvarTracking"
+			"CvarName"		"l4d2_si_spawn_control_max_specials"
+			"CvarType"		"int"
+
+			"1特"
+			{
+				"CvarMatch"				"1"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 1特?"
+				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 1"
+			}
+			"2特"
+			{
+				"CvarMatch"				"2"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 2特?"
+				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 2"
+			}
+			"3特"
+			{
+				"CvarMatch"				"3"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 3特?"
+				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 3"
+			}
+			"4特"
+			{
+				"CvarMatch"				"4"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 4特?"
+				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 4"
+			}
+			"5特"
+			{
+				"CvarMatch"				"5"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 5特?"
+				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 5"
+			}
+			"6特"
+			{
+				"CvarMatch"				"6"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 6特?"
+				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 6"
+			}
+			"7特"
+			{
+				"CvarMatch"				"7"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 7特?"
+				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 7"
+			}
+			"8特"
+			{
+				"CvarMatch"				"8"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 8特?"
+				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 8"
+			}
+			"9特"
+			{
+				"CvarMatch"				"9"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 9特?"
+				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 9"
+			}
+			"10特"
+			{
+				"CvarMatch"				"10"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 10特?"
+				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 10"
+			}
+			"11特"
+			{
+				"CvarMatch"				"11"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 11特?"
+				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 11"
+			}
+			"12特"
+			{
+				"CvarMatch"				"12"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 12特?"
+				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 12"
+			}
+			"13特"
+			{
+				"CvarMatch"				"13"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 13特?"
+				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 13"
+			}
+			"14特"
+			{
+				"CvarMatch"				"14"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 14特?"
+				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 14"
+			}
+			"15特"
+			{
+				"CvarMatch"				"15"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 15特?"
+				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 15"
+			}
+			"16特"
+			{
+				"CvarMatch"				"16"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 16特?"
+				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 16"
+			}
+			"17特"
+			{
+				"CvarMatch"				"17"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 17特?"
+				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 17"
+			}
+			"18特"
+			{
+				"CvarMatch"				"18"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 18特?"
+				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 18"
+			}
+		}
+
+		"特感时间"
+		{
+			"SelectType"	"CvarTracking"
+			"CvarName"		"l4d2_si_spawn_control_spawn_time"
+			"CvarType"		"float"
+
+			"2秒"
+			{
+				"CvarMatch"				"2.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 2秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 2.0"
+			}
+			"4秒"
+			{
+				"CvarMatch"				"4.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 4秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 4.0"
+			}
+			"6秒"
+			{
+				"CvarMatch"				"6.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 6秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 6.0"
+			}
+			"8秒"
+			{
+				"CvarMatch"				"8.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 8秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 8.0"
+			}
+			"10秒"
+			{
+				"CvarMatch"				"10.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 10秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 10.0"
+			}
+			"12秒"
+			{
+				"CvarMatch"				"12.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 12秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 12.0"
+			}
+			"14秒"
+			{
+				"CvarMatch"				"14.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 14秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 14.0"
+			}
+			"16秒"
+			{
+				"CvarMatch"				"16.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 16秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 16.0"
+			}
+			"18秒"
+			{
+				"CvarMatch"				"18.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 18秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 18.0"
+			}
+			"20秒"
+			{
+				"CvarMatch"				"20.0"
+				"Selected"				"1"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 20秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 20.0"
+			}
+			"22秒"
+			{
+				"CvarMatch"				"22.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 22秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 22.0"
+			}
+			"24秒"
+			{
+				"CvarMatch"				"24.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 24秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 24.0"
+			}
+			"26秒"
+			{
+				"CvarMatch"				"26.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 26秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 26.0"
+			}
+			"28秒"
+			{
+				"CvarMatch"				"28.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 28秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 28.0"
+			}
+			"30秒"
+			{
+				"CvarMatch"				"30.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 30秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 30.0"
+			}
+		}
+
+		"特感增强"
+		{
+			"特感连跳"
+			{
+				"SelectType"	"Single"
+
+				"开启特感连跳"
+				{
+					"Selected"				"1"
+					"Type"					"ServerCommand"
+					"AdminOneVotePassed"	"0"
+					"AdminOneVoteAgainst"	"1"
+					"Description"			"开启特感连跳?"
+					"Command"				"sm_cvar ai_boomer_bhop 1;sm_cvar ai_spitter_bhop 1;sm_cvar ai_charger_bhop 1"
+				}
+				"关闭特感连跳"
+				{
+					"Type"					"ServerCommand"
+					"AdminOneVotePassed"	"0"
+					"AdminOneVoteAgainst"	"1"
+					"Description"			"关闭特感连跳?"
+					"Command"				"sm_cvar ai_boomer_bhop 0;sm_cvar ai_spitter_bhop 0;sm_cvar ai_charger_bhop 0"
+				}
+			}
+			"Tank连跳"
+			{
+				"SelectType"	"Single"
+
+				"开启Tank连跳"
+				{
+					"Selected"				"1"
+					"Type"					"ServerCommand"
+					"AdminOneVotePassed"	"0"
+					"AdminOneVoteAgainst"	"1"
+					"Description"			"开启Tank连跳?"
+					"Command"				"sm_cvar ai_tank_bhop 1"
+				}
+			
+				"关闭Tank连跳"
+				{
+					"Type"					"ServerCommand"
+					"AdminOneVotePassed"	"0"
+					"AdminOneVoteAgainst"	"1"
+					"Description"			"关闭Tank连跳?"
+					"Command"				"sm_cvar ai_tank_bhop 0"
+				}
+			}
+		}
 	}
 
 	"加载卸载插件"

--- a/data/l4d2_config_vote.kv
+++ b/data/l4d2_config_vote.kv
@@ -828,7 +828,6 @@
 			"20秒"
 			{
 				"CvarMatch"				"20.0"
-				"Selected"				"1"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"

--- a/data/l4d2_config_vote.kv
+++ b/data/l4d2_config_vote.kv
@@ -1,138 +1,892 @@
 "选择投票类型"
 {
-	"幸存者和特感回血"
-	{
-		"Type"			"ServerCommand"
-		"MenuTeamFlags"	"12"
-		"VoteTeamFlags"	"12"
-		"AdminOneVotePassed" "0"
-		"AdminOneVoteAgainst" "0"
-		"Description"	"幸存者和特感回血?"
-		"Command"		"sm_rehp sur;sm_rehp si"
-	}
-
 	"地图投票"
 	{
-		"Type"			"ExternalVote"
-		"MenuTeamFlags"	"12"
-		"Command"		"sm_votemap"
+		"Type"		"ExternalVote"
+		"Command"	"sm_chmap"
 	}
 
-	"服务器最大玩家数"
+	"更改难度"
 	{
-		"MenuTeamFlags" "14"
-
-		"6"
+		"简单"
 		{
-			"Type"			"ServerCommand"
-			"MenuTeamFlags"	"14"
-			"VoteTeamFlags"	"14"
-			"Description"	"服务器最大玩家数: 6 ?"
-			"Command"		"sm_cvar sv_maxplayers 6"
+			"Type"					"ServerCommand"
+			"AdminOneVotePassed"	"0"
+			"AdminOneVoteAgainst"	"1"
+			"Description"			"更改难度为 简单?"
+			"Command"				"sm_cvar z_difficulty Easy"
 		}
-		"7"
+		"普通"
 		{
-			"Type"			"ServerCommand"
-			"MenuTeamFlags"	"14"
-			"VoteTeamFlags"	"14"
-			"Description"	"服务器最大玩家数: 7 ?"
-			"Command"		"sm_cvar sv_maxplayers 7"
+			"Type"					"ServerCommand"
+			"AdminOneVotePassed"	"0"
+			"AdminOneVoteAgainst"	"1"
+			"Description"			"更改难度为 普通?"
+			"Command"				"sm_cvar z_difficulty Normal"
+		}
+		"高级"
+		{
+			"Type"					"ServerCommand"
+			"AdminOneVotePassed"	"0"
+			"AdminOneVoteAgainst"	"1"
+			"Description"			"更改难度为 高级?"
+			"Command"				"sm_cvar z_difficulty Hard"
+		}
+		"专家"
+		{
+			"Type"					"ServerCommand"
+			"AdminOneVotePassed"	"0"
+			"AdminOneVoteAgainst"	"1"
+			"Description"			"更改难度为 专家?"
+			"Command"				"sm_cvar z_difficulty Impossible"
 		}
 	}
 
-	"特感投票"
+	"更改模式"
 	{
-		"MenuTeamFlags" "12"
+		"官方模式"
+		{
+			"战役模式"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 战役模式?"
+				"Command"				"sm_cvar mp_gamemode coop;sm_restart"
+			}
+			"写实模式"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 写实模式?"
+				"Command"				"sm_cvar mp_gamemode realism;sm_restart"
+			}
+			"对抗模式"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 对抗模式?"
+				"Command"				"sm_cvar mp_gamemode versus;sm_restart"
+			}
+			"写实对抗"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 写实对抗?"
+				"Command"				"sm_cvar mp_gamemode mutation12;sm_restart"
+			}
+			"生还者模式"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 生还者模式?"
+				"Command"				"sm_cvar mp_gamemode survival;sm_restart"
+			}
+			"生还者对抗"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 生还者对抗?"
+				"Command"				"sm_cvar mp_gamemode mutation15;sm_restart"
+			}
+			"清道夫模式"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 清道夫模式?"
+				"Command"				"sm_cvar mp_gamemode scavenge;sm_restart"
+			}
+		}
+		"突变模式"
+		{
+			"特感速递"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 特感速递?"
+				"Command"				"sm_cvar mp_gamemode community1;sm_restart"
+			}
+			"感染季节"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 感染季节?"
+				"Command"				"sm_cvar mp_gamemode community2;sm_restart"
+			}
+			"死亡之门"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 死亡之门?"
+				"Command"				"sm_cvar mp_gamemode community5;sm_restart"
+			}
+			"枪枪爆头"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 枪枪爆头?"
+				"Command"				"sm_cvar mp_gamemode mutation2;sm_restart"
+			}
+			"血流不止"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 血流不止?"
+				"Command"				"sm_cvar mp_gamemode mutation3;sm_restart"
+			}
+			"绝境求生"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 绝境求生?"
+				"Command"				"sm_cvar mp_gamemode mutation4;sm_restart"
+			}
+			"铁人意志"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 铁人意志?"
+				"Command"				"sm_cvar mp_gamemode mutation8;sm_restart"
+			}
+			"侏儒卫队"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 侏儒卫队?"
+				"Command"				"sm_cvar mp_gamemode mutation9;sm_restart"
+			}
+			"无法近身"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 无法近身?"
+				"Command"				"sm_cvar mp_gamemode mutation14;sm_restart"
+			}
+			"猎人派对"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 猎人派对?"
+				"Command"				"sm_cvar mp_gamemode mutation16;sm_restart"
+			}
+			"骑师派对"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 骑师派对?"
+				"Command"				"sm_cvar mp_gamemode community3;sm_restart"
+			}
+			"没有救赎"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 没有救赎?"
+				"Command"				"sm_cvar mp_gamemode mutation11;sm_restart"
+			}
+			"清道肆虐"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 清道肆虐?"
+				"Command"				"sm_cvar mp_gamemode mutation13;sm_restart"
+			}
+			"失血对抗"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 失血对抗?"
+				"Command"				"sm_cvar mp_gamemode mutation18;sm_restart"
+			}
+			"坦克派对"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 坦克派对?"
+				"Command"				"sm_cvar mp_gamemode mutation19;sm_restart"
+			}
+			"孤身一人"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 孤身一人?"
+				"Command"				"sm_cvar mp_gamemode mutation1;sm_restart"
+			}
+			"孤胆枪手"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改模式为 孤胆枪手?"
+				"Command"				"sm_cvar mp_gamemode mutation17;sm_restart"
+			}
+		}
+		"match模式"
+		{
+			"Type"		"ExternalVote"
+			"Command"	"sm_chmatch"
+		}
+		"卸载当前match模式"
+		{
+			"Type"		"ExternalVote"
+			"Command"	"sm_rmatch"
+		}
+	}
+
+	"游戏设置"
+	{
+		"重启当前章节"
+		{
+			"Type"					"ServerCommand"
+			"MenuTeamFlags"			"14"
+			"VoteTeamFlags"			"14"
+			"AdminOneVotePassed"	"0"
+			"AdminOneVoteAgainst"	"1"
+			"Description"			"重启当前章节?"
+			"Command"				"sm_restart"
+		}
+
+		"后备弹药设置"
+		{
+			"SelectType"	"Single"
+
+			"开启2倍后备弹药"
+			{
+				"Type"					"ServerCommand"
+				"MenuTeamFlags"			"14"
+				"VoteTeamFlags"			"14"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"开启2倍后备弹药?"
+				"Command"				"sm_mammo 2"
+			}
+			"开启3倍后备弹药"
+			{
+				"Type"					"ServerCommand"
+				"MenuTeamFlags"			"14"
+				"VoteTeamFlags"			"14"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"开启3倍后备弹药?"
+				"Command"				"sm_mammo 3"
+			}
+			"开启无限后备弹药"
+			{
+				"Type"					"ServerCommand"
+				"MenuTeamFlags"			"14"
+				"VoteTeamFlags"			"14"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"开启无限后备弹药?"
+				"Command"				"sm_mammo -1"
+			}
+			"关闭更多后备弹药"
+			{
+				"Selected"				"1"
+				"Type"					"ServerCommand"
+				"MenuTeamFlags"			"14"
+				"VoteTeamFlags"			"14"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"关闭更多后备弹药?"
+				"Command"				"sm_mammo 0"
+			}
+		}
+
+		"黑枪提示设置"
+		{
+			"SelectType"	"Single"
+
+			"开启黑枪文字提示"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"开启黑枪文字提示?"
+				"Command"				"sm_cvar l4d_broadcast_ff 3;sm_cvar l4d_broadcast_hit 1"
+			}
+			"关闭黑枪文字提示"
+			{
+				"Selected"				"1"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"关闭黑枪文字提示?"
+				"Command"				"sm_cvar l4d_broadcast_ff 0;sm_cvar l4d_broadcast_hit 0"
+			}
+		}
+
+		"血量显示设置"
+		{
+			"SelectType"	"Single"
+
+			"开启特感血量显示"
+			{
+				"Selected"				"1"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"开启特感血量显示?"
+				"Command"				"sm_cvar l4d_broadcast_kill 1;sm_cvar l4d_infectedhp 1"
+			}
+			"关闭特感血量显示"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"关闭特感血量显示?"
+				"Command"				"sm_cvar l4d_broadcast_kill 0;sm_cvar l4d_infectedhp 0"
+			}
+		}
+
+		"最大人数设置"
+		{
+			"4人"
+			{
+				"Type"		"ExternalVote"
+				"Command"	"sm_slots 4"
+			}
+			"8人"
+			{
+				"Type"		"ExternalVote"
+				"Command"	"sm_slots 8"
+			}
+			"12人"
+			{
+				"Type"		"ExternalVote"
+				"Command"	"sm_slots 12"
+			}
+			"16人"
+			{
+				"Type"		"ExternalVote"
+				"Command"	"sm_slots 16"
+			}
+			"20人"
+			{
+				"Type"		"ExternalVote"
+				"Command"	"sm_slots 20"
+			}
+			"24人"
+			{
+				"Type"		"ExternalVote"
+				"Command"	"sm_slots 24"
+			}
+			"28人"
+			{
+				"Type"		"ExternalVote"
+				"Command"	"sm_slots 28"
+			}
+		}
+	}
+
+	"友伤设置"
+	{
+		"友伤"
+		{
+			"SelectType"	"Single"
+
+			"开启队友伤害"
+			{
+				"Selected"				"1"
+				"Type"					"ServerCommand"
+				"MenuTeamFlags"			"14"
+				"VoteTeamFlags"			"14"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"开启队友伤害?"
+				"Command"				"sm_noff 1;exec vote/reflect_ff_off.cfg"
+			}
+			"关闭队友伤害"
+			{
+				"Type"					"ServerCommand"
+				"MenuTeamFlags"			"14"
+				"VoteTeamFlags"			"14"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"关闭队友伤害?"
+				"Command"				"sm_noff 0"
+			}
+		}
+		"反伤"
+		{
+			"SelectType"	"Single"
+
+			"开启反射友伤"
+			{
+				"Type"					"ServerCommand"
+				"MenuTeamFlags"			"14"
+				"VoteTeamFlags"			"14"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"开启反射友伤?"
+				"Command"				"sm_noff 1;exec vote/reflect_ff_on.cfg"
+			}
+			"关闭反射友伤"
+			{
+				"Selected"				"1"
+				"Type"					"ServerCommand"
+				"MenuTeamFlags"			"14"
+				"VoteTeamFlags"			"14"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"关闭反射友伤?"
+				"Command"				"exec vote/reflect_ff_off.cfg"
+			}
+		}
+	}
+
+	"人机设置"
+	{
+		"踢出所有电脑"
+		{
+			"Type"					"ServerCommand"
+			"MenuTeamFlags"			"14"
+			"VoteTeamFlags"			"14"
+			"AdminOneVotePassed"	"0"
+			"AdminOneVoteAgainst"	"1"
+			"Description"			"踢出所有电脑?"
+			"Command"				"sm_kb"
+		}
+	}
+
+	"特感设置"
+	{
+		"杀特回血"
+		{
+			"SelectType"	"Single"
+
+			"开启击杀特感回复 1 血量"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"开启击杀特感回复 1 血量?"
+				"Command"				"exec vote/kill_si_restore_health_1.cfg"
+			}
+			"开启击杀特感回复 2 血量"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"开启击杀特感回复 2 血量?"
+				"Command"				"exec vote/kill_si_restore_health_2.cfg"
+			}
+			"开启击杀特感回复 3 血量"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"开启击杀特感回复 3 血量?"
+				"Command"				"exec vote/kill_si_restore_health_3.cfg"
+			}
+			"开启击杀特感回复 5 血量"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"开启击杀特感回复 5 血量?"
+				"Command"				"exec vote/kill_si_restore_health_5.cfg"
+			}
+			"开启击杀特感回复 10 血量"
+			{
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"开启击杀特感回复 10 血量?"
+				"Command"				"exec vote/kill_si_restore_health_10.cfg"
+			}
+			"关闭击杀特感回复血量"
+			{
+				"Selected"				"1"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"关闭击杀特感回复血量?"
+				"Command"				"exec vote/kill_si_restore_health_off.cfg"
+			}
+		}
 
 		"特感数量"
 		{
-			"MenuTeamFlags" "12"
+			"SelectType"	"CvarTracking"
+			"CvarName"		"l4d2_si_spawn_control_max_specials"
+			"CvarType"		"int"
 
-			"1 特"
+			"1特"
 			{
-				"Type"			"ServerCommand"
-				"MenuTeamFlags"	"12"
-				"VoteTeamFlags"	"12"
-				"Description"	"特感数量: 1 特?"
-				"Command"		"exec \"sivote/si_limit/1si.cfg\""
+				"CvarMatch"				"1"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 1特?"
+				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 1"
 			}
-			"2 特"
+			"2特"
 			{
-				"Type"			"ServerCommand"
-				"MenuTeamFlags"	"12"
-				"VoteTeamFlags"	"12"
-				"Description"	"特感数量: 2 特?"
-				"Command"		"exec \"sivote/si_limit/2si.cfg\""
+				"CvarMatch"				"2"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 2特?"
+				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 2"
+			}
+			"3特"
+			{
+				"CvarMatch"				"3"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 3特?"
+				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 3"
+			}
+			"4特"
+			{
+				"CvarMatch"				"4"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 4特?"
+				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 4"
+			}
+			"5特"
+			{
+				"CvarMatch"				"5"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 5特?"
+				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 5"
+			}
+			"6特"
+			{
+				"CvarMatch"				"6"
+				"Selected"				"1"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 6特?"
+				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 6"
+			}
+			"7特"
+			{
+				"CvarMatch"				"7"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 7特?"
+				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 7"
+			}
+			"8特"
+			{
+				"CvarMatch"				"8"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 8特?"
+				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 8"
+			}
+			"9特"
+			{
+				"CvarMatch"				"9"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 9特?"
+				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 9"
+			}
+			"10特"
+			{
+				"CvarMatch"				"10"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 10特?"
+				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 10"
+			}
+			"11特"
+			{
+				"CvarMatch"				"11"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 11特?"
+				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 11"
+			}
+			"12特"
+			{
+				"CvarMatch"				"12"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 12特?"
+				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 12"
+			}
+			"13特"
+			{
+				"CvarMatch"				"13"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 13特?"
+				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 13"
+			}
+			"14特"
+			{
+				"CvarMatch"				"14"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 14特?"
+				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 14"
+			}
+			"15特"
+			{
+				"CvarMatch"				"15"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 15特?"
+				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 15"
+			}
+			"16特"
+			{
+				"CvarMatch"				"16"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 16特?"
+				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 16"
+			}
+			"17特"
+			{
+				"CvarMatch"				"17"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 17特?"
+				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 17"
+			}
+			"18特"
+			{
+				"CvarMatch"				"18"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感数量为 18特?"
+				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 18"
 			}
 		}
 
-		"特感刷新时间"
+		"特感时间"
 		{
-			"MenuTeamFlags" "12"
+			"SelectType"	"CvarTracking"
+			"CvarName"		"l4d2_si_spawn_control_spawn_time"
+			"CvarType"		"float"
 
-			"1 秒"
+			"2秒"
 			{
-				"Type"			"ServerCommand"
-				"MenuTeamFlags"	"12"
-				"VoteTeamFlags"	"12"
-				"Description"	"特感刷新时间: 1 秒?"
-				"Command"		"sm_cvar l4d2_si_spawn_control_spawn_time 1"
+				"CvarMatch"				"2.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 2秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 2.0"
 			}
-			"2 秒"
+			"4秒"
 			{
-				"Type"			"ServerCommand"
-				"MenuTeamFlags"	"12"
-				"VoteTeamFlags"	"12"
-				"Description"	"特感刷新时间: 2 秒?"
-				"Command"		"sm_cvar l4d2_si_spawn_control_spawn_time 2"
+				"CvarMatch"				"4.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 4秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 4.0"
+			}
+			"6秒"
+			{
+				"CvarMatch"				"6.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 6秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 6.0"
+			}
+			"8秒"
+			{
+				"CvarMatch"				"8.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 8秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 8.0"
+			}
+			"10秒"
+			{
+				"CvarMatch"				"10.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 10秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 10.0"
+			}
+			"12秒"
+			{
+				"CvarMatch"				"12.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 12秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 12.0"
+			}
+			"14秒"
+			{
+				"CvarMatch"				"14.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 14秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 14.0"
+			}
+			"16秒"
+			{
+				"CvarMatch"				"16.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 16秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 16.0"
+			}
+			"18秒"
+			{
+				"CvarMatch"				"18.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 18秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 18.0"
+			}
+			"20秒"
+			{
+				"CvarMatch"				"20.0"
+				"Selected"				"1"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 20秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 20.0"
+			}
+			"22秒"
+			{
+				"CvarMatch"				"22.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 22秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 22.0"
+			}
+			"24秒"
+			{
+				"CvarMatch"				"24.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 24秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 24.0"
+			}
+			"26秒"
+			{
+				"CvarMatch"				"26.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 26秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 26.0"
+			}
+			"28秒"
+			{
+				"CvarMatch"				"28.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 28秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 28.0"
+			}
+			"30秒"
+			{
+				"CvarMatch"				"30.0"
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"更改特感刷新时间为 30秒?"
+				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 30.0"
 			}
 		}
 
-		"其他特感投票"
+		"特感增强"
 		{
-			"MenuTeamFlags" "12"
-
-			"特感攻击性补丁"
+			"特感连跳"
 			{
-				"MenuTeamFlags" "4"
+				"SelectType"	"Single"
 
-				"开启"
+				"开启特感连跳"
 				{
-					"Type"			"ServerCommand"
-					"MenuTeamFlags"	"4"
-					"VoteTeamFlags"	"4"
-					"Description"	"特感攻击性补丁: 开启?"
-					"Command"		"sm_cvar aggresive_specials_patch_enable 1"
+					"Selected"				"1"
+					"Type"					"ServerCommand"
+					"AdminOneVotePassed"	"0"
+					"AdminOneVoteAgainst"	"1"
+					"Description"			"开启特感连跳?"
+					"Command"				"sm_cvar ai_boomer_bhop 1;sm_cvar ai_spitter_bhop 1;sm_cvar ai_charger_bhop 1"
 				}
-				"关闭"
+				"关闭特感连跳"
 				{
-					"Type"			"ServerCommand"
-					"MenuTeamFlags"	"4"
-					"VoteTeamFlags"	"4"
-					"Description"	"特感攻击性补丁: 关闭?"
-					"Command"		"sm_cvar aggresive_specials_patch_enable 0"
+					"Type"					"ServerCommand"
+					"AdminOneVotePassed"	"0"
+					"AdminOneVoteAgainst"	"1"
+					"Description"			"关闭特感连跳?"
+					"Command"				"sm_cvar ai_boomer_bhop 0;sm_cvar ai_spitter_bhop 0;sm_cvar ai_charger_bhop 0"
 				}
 			}
-
-			"击杀回血"
+			"Tank连跳"
 			{
-				"MenuTeamFlags" "12"
+				"SelectType"	"Single"
 
-				"击杀特感回1血"
+				"开启Tank连跳"
 				{
-					"Type"			"ServerCommand"
-					"MenuTeamFlags"	"12"
-					"VoteTeamFlags"	"12"
-					"Description"	"击杀特感回 1 血?"
-					"Command"		"exec \"sivote/rehp/1.cfg\""
+					"Selected"				"1"
+					"Type"					"ServerCommand"
+					"AdminOneVotePassed"	"0"
+					"AdminOneVoteAgainst"	"1"
+					"Description"			"开启Tank连跳?"
+					"Command"				"sm_cvar ai_tank_bhop 1"
 				}
-				"击杀特感回2血"
+			
+				"关闭Tank连跳"
 				{
-					"Type"			"ServerCommand"
-					"MenuTeamFlags"	"12"
-					"VoteTeamFlags"	"12"
-					"Description"	"击杀特感回 2 血?"
-					"Command"		"exec \"sivote/rehp/2.cfg\""
+					"Type"					"ServerCommand"
+					"AdminOneVotePassed"	"0"
+					"AdminOneVoteAgainst"	"1"
+					"Description"			"关闭Tank连跳?"
+					"Command"				"sm_cvar ai_tank_bhop 0"
 				}
 			}
 		}

--- a/data/l4d2_config_vote.kv
+++ b/data/l4d2_config_vote.kv
@@ -8,8 +8,13 @@
 
 	"更改难度"
 	{
+		"SelectType"	"CvarTracking"
+		"CvarName"		"z_difficulty"
+		"CvarType"		"string"
+
 		"简单"
 		{
+			"CvarMatch"				"Easy"
 			"Type"					"ServerCommand"
 			"AdminOneVotePassed"	"0"
 			"AdminOneVoteAgainst"	"1"
@@ -18,6 +23,7 @@
 		}
 		"普通"
 		{
+			"CvarMatch"				"Normal"
 			"Type"					"ServerCommand"
 			"AdminOneVotePassed"	"0"
 			"AdminOneVoteAgainst"	"1"
@@ -26,6 +32,7 @@
 		}
 		"高级"
 		{
+			"CvarMatch"				"Hard"
 			"Type"					"ServerCommand"
 			"AdminOneVotePassed"	"0"
 			"AdminOneVoteAgainst"	"1"
@@ -34,6 +41,7 @@
 		}
 		"专家"
 		{
+			"CvarMatch"				"Impossible"
 			"Type"					"ServerCommand"
 			"AdminOneVotePassed"	"0"
 			"AdminOneVoteAgainst"	"1"
@@ -46,8 +54,13 @@
 	{
 		"官方模式"
 		{
+			"SelectType"	"CvarTracking"
+			"CvarName"		"mp_gamemode"
+			"CvarType"		"string"
+
 			"战役模式"
 			{
+				"CvarMatch"				"coop"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -56,6 +69,7 @@
 			}
 			"写实模式"
 			{
+				"CvarMatch"				"realism"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -64,6 +78,7 @@
 			}
 			"对抗模式"
 			{
+				"CvarMatch"				"versus"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -72,6 +87,7 @@
 			}
 			"写实对抗"
 			{
+				"CvarMatch"				"mutation12"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -80,6 +96,7 @@
 			}
 			"生还者模式"
 			{
+				"CvarMatch"				"survival"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -88,6 +105,7 @@
 			}
 			"生还者对抗"
 			{
+				"CvarMatch"				"mutation15"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -96,6 +114,7 @@
 			}
 			"清道夫模式"
 			{
+				"CvarMatch"				"scavenge"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -105,8 +124,13 @@
 		}
 		"突变模式"
 		{
+			"SelectType"	"CvarTracking"
+			"CvarName"		"mp_gamemode"
+			"CvarType"		"string"
+
 			"特感速递"
 			{
+				"CvarMatch"				"community1"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -115,6 +139,7 @@
 			}
 			"感染季节"
 			{
+				"CvarMatch"				"community2"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -123,6 +148,7 @@
 			}
 			"死亡之门"
 			{
+				"CvarMatch"				"community5"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -131,6 +157,7 @@
 			}
 			"枪枪爆头"
 			{
+				"CvarMatch"				"mutation2"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -139,6 +166,7 @@
 			}
 			"血流不止"
 			{
+				"CvarMatch"				"mutation3"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -147,6 +175,7 @@
 			}
 			"绝境求生"
 			{
+				"CvarMatch"				"mutation4"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -155,6 +184,7 @@
 			}
 			"铁人意志"
 			{
+				"CvarMatch"				"mutation8"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -163,6 +193,7 @@
 			}
 			"侏儒卫队"
 			{
+				"CvarMatch"				"mutation9"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -171,6 +202,7 @@
 			}
 			"无法近身"
 			{
+				"CvarMatch"				"mutation14"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -179,6 +211,7 @@
 			}
 			"猎人派对"
 			{
+				"CvarMatch"				"mutation16"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -187,6 +220,7 @@
 			}
 			"骑师派对"
 			{
+				"CvarMatch"				"community3"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -195,6 +229,7 @@
 			}
 			"没有救赎"
 			{
+				"CvarMatch"				"mutation11"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -203,6 +238,7 @@
 			}
 			"清道肆虐"
 			{
+				"CvarMatch"				"mutation13"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -211,6 +247,7 @@
 			}
 			"失血对抗"
 			{
+				"CvarMatch"				"mutation18"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -219,6 +256,7 @@
 			}
 			"坦克派对"
 			{
+				"CvarMatch"				"mutation19"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -227,6 +265,7 @@
 			}
 			"孤身一人"
 			{
+				"CvarMatch"				"mutation1"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -235,6 +274,7 @@
 			}
 			"孤胆枪手"
 			{
+				"CvarMatch"				"mutation17"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
@@ -245,12 +285,7 @@
 		"match模式"
 		{
 			"Type"		"ExternalVote"
-			"Command"	"sm_chmatch"
-		}
-		"卸载当前match模式"
-		{
-			"Type"		"ExternalVote"
-			"Command"	"sm_rmatch"
+			"Command"	"sm_match"
 		}
 	}
 
@@ -402,6 +437,8 @@
 
 	"友伤设置"
 	{
+		"MenuModeFlags"	"11"
+
 		"友伤"
 		{
 			"SelectType"	"Single"
@@ -458,6 +495,8 @@
 
 	"人机设置"
 	{
+		"MenuModeFlags"	"11"
+
 		"踢出所有电脑"
 		{
 			"Type"					"ServerCommand"
@@ -472,6 +511,8 @@
 
 	"特感设置"
 	{
+		"MenuModeFlags"	"11"
+
 		"杀特回血"
 		{
 			"SelectType"	"Single"
@@ -526,368 +567,55 @@
 				"Command"				"exec vote/kill_si_restore_health_off.cfg"
 			}
 		}
+	}
 
-		"特感数量"
+	"加载卸载插件"
+	{
+		"SelectType"	"PluginTracking"
+
+		"娱乐插件A"
 		{
-			"SelectType"	"CvarTracking"
-			"CvarName"		"l4d2_si_spawn_control_max_specials"
-			"CvarType"		"int"
+			"PluginMatch"	"optional/aaa.smx"
 
-			"1特"
+			"开启"
 			{
-				"CvarMatch"				"1"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 1特?"
-				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 1"
+				"Description"			"加载娱乐插件A?"
+				"Command"				"sm plugins load optional/aaa.smx"
 			}
-			"2特"
+
+			"关闭"
 			{
-				"CvarMatch"				"2"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 2特?"
-				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 2"
-			}
-			"3特"
-			{
-				"CvarMatch"				"3"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 3特?"
-				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 3"
-			}
-			"4特"
-			{
-				"CvarMatch"				"4"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 4特?"
-				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 4"
-			}
-			"5特"
-			{
-				"CvarMatch"				"5"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 5特?"
-				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 5"
-			}
-			"6特"
-			{
-				"CvarMatch"				"6"
-				"Selected"				"1"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 6特?"
-				"Command"				"exec vote/special_limit_1.cfg;sm_cvar l4d2_si_spawn_control_max_specials 6"
-			}
-			"7特"
-			{
-				"CvarMatch"				"7"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 7特?"
-				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 7"
-			}
-			"8特"
-			{
-				"CvarMatch"				"8"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 8特?"
-				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 8"
-			}
-			"9特"
-			{
-				"CvarMatch"				"9"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 9特?"
-				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 9"
-			}
-			"10特"
-			{
-				"CvarMatch"				"10"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 10特?"
-				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 10"
-			}
-			"11特"
-			{
-				"CvarMatch"				"11"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 11特?"
-				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 11"
-			}
-			"12特"
-			{
-				"CvarMatch"				"12"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 12特?"
-				"Command"				"exec vote/special_limit_2.cfg;sm_cvar l4d2_si_spawn_control_max_specials 12"
-			}
-			"13特"
-			{
-				"CvarMatch"				"13"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 13特?"
-				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 13"
-			}
-			"14特"
-			{
-				"CvarMatch"				"14"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 14特?"
-				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 14"
-			}
-			"15特"
-			{
-				"CvarMatch"				"15"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 15特?"
-				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 15"
-			}
-			"16特"
-			{
-				"CvarMatch"				"16"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 16特?"
-				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 16"
-			}
-			"17特"
-			{
-				"CvarMatch"				"17"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 17特?"
-				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 17"
-			}
-			"18特"
-			{
-				"CvarMatch"				"18"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感数量为 18特?"
-				"Command"				"exec vote/special_limit_3.cfg;sm_cvar l4d2_si_spawn_control_max_specials 18"
+				"Description"			"卸载娱乐插件A?"
+				"Command"				"sm plugins unload optional/aaa.smx"
 			}
 		}
 
-		"特感时间"
+		"娱乐插件B"
 		{
-			"SelectType"	"CvarTracking"
-			"CvarName"		"l4d2_si_spawn_control_spawn_time"
-			"CvarType"		"float"
+			"PluginMatch"	"optional/bbb.smx"
 
-			"2秒"
+			"开启"
 			{
-				"CvarMatch"				"2.0"
 				"Type"					"ServerCommand"
 				"AdminOneVotePassed"	"0"
 				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感刷新时间为 2秒?"
-				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 2.0"
+				"Description"			"加载娱乐插件B?"
+				"Command"				"sm plugins load optional/bbb.smx"
 			}
-			"4秒"
-			{
-				"CvarMatch"				"4.0"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感刷新时间为 4秒?"
-				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 4.0"
-			}
-			"6秒"
-			{
-				"CvarMatch"				"6.0"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感刷新时间为 6秒?"
-				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 6.0"
-			}
-			"8秒"
-			{
-				"CvarMatch"				"8.0"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感刷新时间为 8秒?"
-				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 8.0"
-			}
-			"10秒"
-			{
-				"CvarMatch"				"10.0"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感刷新时间为 10秒?"
-				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 10.0"
-			}
-			"12秒"
-			{
-				"CvarMatch"				"12.0"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感刷新时间为 12秒?"
-				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 12.0"
-			}
-			"14秒"
-			{
-				"CvarMatch"				"14.0"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感刷新时间为 14秒?"
-				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 14.0"
-			}
-			"16秒"
-			{
-				"CvarMatch"				"16.0"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感刷新时间为 16秒?"
-				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 16.0"
-			}
-			"18秒"
-			{
-				"CvarMatch"				"18.0"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感刷新时间为 18秒?"
-				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 18.0"
-			}
-			"20秒"
-			{
-				"CvarMatch"				"20.0"
-				"Selected"				"1"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感刷新时间为 20秒?"
-				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 20.0"
-			}
-			"22秒"
-			{
-				"CvarMatch"				"22.0"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感刷新时间为 22秒?"
-				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 22.0"
-			}
-			"24秒"
-			{
-				"CvarMatch"				"24.0"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感刷新时间为 24秒?"
-				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 24.0"
-			}
-			"26秒"
-			{
-				"CvarMatch"				"26.0"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感刷新时间为 26秒?"
-				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 26.0"
-			}
-			"28秒"
-			{
-				"CvarMatch"				"28.0"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感刷新时间为 28秒?"
-				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 28.0"
-			}
-			"30秒"
-			{
-				"CvarMatch"				"30.0"
-				"Type"					"ServerCommand"
-				"AdminOneVotePassed"	"0"
-				"AdminOneVoteAgainst"	"1"
-				"Description"			"更改特感刷新时间为 30秒?"
-				"Command"				"sm_cvar l4d2_si_spawn_control_spawn_time 30.0"
-			}
-		}
 
-		"特感增强"
-		{
-			"特感连跳"
+			"关闭"
 			{
-				"SelectType"	"Single"
-
-				"开启特感连跳"
-				{
-					"Selected"				"1"
-					"Type"					"ServerCommand"
-					"AdminOneVotePassed"	"0"
-					"AdminOneVoteAgainst"	"1"
-					"Description"			"开启特感连跳?"
-					"Command"				"sm_cvar ai_boomer_bhop 1;sm_cvar ai_spitter_bhop 1;sm_cvar ai_charger_bhop 1"
-				}
-				"关闭特感连跳"
-				{
-					"Type"					"ServerCommand"
-					"AdminOneVotePassed"	"0"
-					"AdminOneVoteAgainst"	"1"
-					"Description"			"关闭特感连跳?"
-					"Command"				"sm_cvar ai_boomer_bhop 0;sm_cvar ai_spitter_bhop 0;sm_cvar ai_charger_bhop 0"
-				}
-			}
-			"Tank连跳"
-			{
-				"SelectType"	"Single"
-
-				"开启Tank连跳"
-				{
-					"Selected"				"1"
-					"Type"					"ServerCommand"
-					"AdminOneVotePassed"	"0"
-					"AdminOneVoteAgainst"	"1"
-					"Description"			"开启Tank连跳?"
-					"Command"				"sm_cvar ai_tank_bhop 1"
-				}
-			
-				"关闭Tank连跳"
-				{
-					"Type"					"ServerCommand"
-					"AdminOneVotePassed"	"0"
-					"AdminOneVoteAgainst"	"1"
-					"Description"			"关闭Tank连跳?"
-					"Command"				"sm_cvar ai_tank_bhop 0"
-				}
+				"Type"					"ServerCommand"
+				"AdminOneVotePassed"	"0"
+				"AdminOneVoteAgainst"	"1"
+				"Description"			"卸载娱乐插件B?"
+				"Command"				"sm plugins unload optional/bbb.smx"
 			}
 		}
 	}

--- a/scripting/l4d2_config_vote.sp
+++ b/scripting/l4d2_config_vote.sp
@@ -6,7 +6,7 @@
 #include <l4d2_source_keyvalues>	// https://github.com/fdxx/l4d2_source_keyvalues
 #include <multicolors>
 
-#define VERSION "0.7"
+#define VERSION "0.8"
 #define COMMAND_MAX_LENGTH 511
 
 #define TEAMFLAGS_SPEC	2
@@ -121,7 +121,7 @@ void ShowMenu(int client, SourceKeyValues kv, bool bBackButton = true)
 	}
 
 	menu.ExitBackButton = bBackButton;
-	menu.Display(client, 20);
+	menu.Display(client, MENU_TIME_FOREVER);
 }
 
 int MenuHandlerCB(Menu menu, MenuAction action, int client, int itemNum)

--- a/scripting/l4d2_config_vote.sp
+++ b/scripting/l4d2_config_vote.sp
@@ -2,30 +2,46 @@
 #pragma newdecls required
 
 #include <sourcemod>
+#include <left4dhooks>				// https://github.com/SilvDev/Left4DHooks
 #include <l4d2_nativevote>			// https://github.com/fdxx/l4d2_nativevote
 #include <l4d2_source_keyvalues>	// https://github.com/fdxx/l4d2_source_keyvalues
 #include <multicolors>
 
-#define VERSION "0.8"
+#define VERSION "0.9"
+#define CUSTOM_FLAG_LIST_MAX_SIZE 32
+#define CUSTOM_FLAG_MAX_LENGTH 32
 #define COMMAND_MAX_LENGTH 511
 
-#define TEAMFLAGS_SPEC	2
-#define TEAMFLAGS_SUR	4
-#define TEAMFLAGS_INF	8
-#define TEAMFLAGS_DEFAULT	(TEAMFLAGS_SPEC|TEAMFLAGS_SUR|TEAMFLAGS_INF)
+#define CUSTOMFLAGS_DEFAULT ""
+
+#define INVALID_FLAGS       0
+
+#define MODEFLAGS_COOP      1
+#define MODEFLAGS_REALISM   2
+#define MODEFLAGS_VERSUS    4
+#define MODEFLAGS_SURVIVAL  8
+#define MODEFLAGS_SCAVENGE  16
+#define MODEFLAGS_DEFAULT   (MODEFLAGS_COOP | MODEFLAGS_REALISM | MODEFLAGS_VERSUS | MODEFLAGS_SURVIVAL | MODEFLAGS_SCAVENGE)
+
+#define TEAMFLAGS_SPEC      2
+#define TEAMFLAGS_SUR       4
+#define TEAMFLAGS_INF       8
+#define TEAMFLAGS_DEFAULT   (TEAMFLAGS_SPEC | TEAMFLAGS_SUR | TEAMFLAGS_INF)
 
 enum ConfigType
 {
-	Type_NotFound = 0,
-	Type_ServerCommand,
-	Type_ClientCommand,
-	Type_ExternalVote,
-	Type_CheatCommand,
+	ConfigType_NotFound = 0,
+	ConfigType_ServerCommand,
+	ConfigType_ClientCommand,
+	ConfigType_ExternalVote,
+	ConfigType_CheatCommand,
 }
 
 enum struct ConfigData
 {
 	ConfigType type;
+	int menuCustomFlags;
+	int menuModeFlags;
 	int menuTeamFlags;
 	int voteTeamFlags;
 	bool bAdminOneVotePassed;
@@ -35,11 +51,11 @@ enum struct ConfigData
 }
 
 SourceKeyValues
-	g_kvSelect[MAXPLAYERS+1],
+	g_kvSelect[MAXPLAYERS + 1],
 	g_kvRoot;
 
-ConVar g_cvVoteFilePath, g_cvAdminTeamFlags, g_cvPrintMsg, g_cvPassMode;
-ConfigData g_cfgData[MAXPLAYERS+1];
+ConVar g_cvVoteFilePath, g_cvMenuCustomFlags, g_cvAdminTeamFlags, g_cvPrintMsg, g_cvPassMode;
+ConfigData g_cfgData[MAXPLAYERS + 1];
 
 public Plugin myinfo = 
 {
@@ -58,6 +74,7 @@ public void OnPluginStart()
 {
 	CreateConVar("l4d2_config_vote_version", VERSION, "version", FCVAR_NOTIFY | FCVAR_DONTRECORD);
 	g_cvVoteFilePath = CreateConVar("l4d2_config_vote_path", "data/l4d2_config_vote.kv", "Vote config file path.");
+	g_cvMenuCustomFlags = CreateConVar("l4d2_config_vote_menucustomflags", "", "Menu custom flags (',' separated).");
 	g_cvAdminTeamFlags = CreateConVar("l4d2_config_vote_adminteamflags", "1", "Admin bypass TeamFlags.");
 	g_cvPrintMsg = CreateConVar("l4d2_config_vote_printmsg", "1", "Whether print hint message to clients.");
 	g_cvPassMode = CreateConVar("l4d2_config_vote_passmode", "1", "Method of judging vote pass. 0=Vote Yes count > Vote No count. 1=Vote Yes count > Half of players count.");
@@ -99,7 +116,7 @@ void ShowMenu(int client, SourceKeyValues kv, bool bBackButton = true)
 {
 	if (client < 1 || !IsClientInGame(client) || IsFakeClient(client))
 		return;
-	
+
 	if (!kv)
 		ThrowError("Invalid SourceKeyValues pointer!");
 
@@ -110,12 +127,20 @@ void ShowMenu(int client, SourceKeyValues kv, bool bBackButton = true)
 
 	Menu menu = new Menu(MenuHandlerCB);
 	menu.SetTitle("%s:", title);
-	
+
 	for (SourceKeyValues sub = kv.GetFirstTrueSubKey(); sub; sub = sub.GetNextTrueSubKey())
 	{
+		char customFlag[128];
+		sub.GetString("MenuCustomFlags", customFlag, sizeof(customFlag), CUSTOMFLAGS_DEFAULT);
+		if (!IsValidCustomFlags(customFlag))
+			continue;
+
+		if (!IsValidModeFlags(sub.GetInt("MenuModeFlags", MODEFLAGS_DEFAULT)))
+			continue;
+
 		if (!IsValidTeamFlags(client, sub.GetInt("MenuTeamFlags", TEAMFLAGS_DEFAULT)))
 			continue;
-		
+
 		sub.GetName(display, sizeof(display));
 		IntToString(view_as<int>(sub), sKv, sizeof(sKv));
 		menu.AddItem(sKv, display);
@@ -135,15 +160,15 @@ int MenuHandlerCB(Menu menu, MenuAction action, int client, int itemNum)
 			menu.GetItem(itemNum, sKv, sizeof(sKv));
 
 			SourceKeyValues kv = view_as<SourceKeyValues>(StringToInt(sKv));
-			ConfigType type = GetConfigType(kv);
+			ConfigType configType = GetConfigType(kv);
 
-			switch (type)
+			switch (configType)
 			{
-				case Type_NotFound:
+				case ConfigType_NotFound:
 				{
 					ShowMenu(client, kv);
 				}
-				case Type_ExternalVote:
+				case ConfigType_ExternalVote:
 				{
 					char cmd[COMMAND_MAX_LENGTH];
 					kv.GetString("Command", cmd, sizeof(cmd));
@@ -151,7 +176,7 @@ int MenuHandlerCB(Menu menu, MenuAction action, int client, int itemNum)
 				}
 				default:
 				{
-					StartVote(client, kv, type);
+					StartVote(client, kv, configType);
 				}
 			}
 		}
@@ -185,7 +210,7 @@ void StartVote(int client, SourceKeyValues kv, ConfigType type)
 	g_cfgData[client].bAdminOneVoteAgainst = kv.GetInt("AdminOneVoteAgainst", 1) > 0;
 	kv.GetString("Description", g_cfgData[client].description, sizeof(g_cfgData[].description));
 	kv.GetString("Command", g_cfgData[client].cmd, sizeof(g_cfgData[].cmd));
-	
+
 	L4D2NativeVote vote = L4D2NativeVote(Vote_Handler);
 	vote.SetDisplayText("%s", g_cfgData[client].description);
 	vote.Initiator = client;
@@ -245,16 +270,16 @@ void Vote_Handler(L4D2NativeVote vote, VoteAction action, int param1, int param2
 
 				switch (g_cfgData[vote.Initiator].type)
 				{
-					case Type_ServerCommand:
+					case ConfigType_ServerCommand:
 					{
 						ServerCommand("%s", g_cfgData[vote.Initiator].cmd);
 					}
-					case Type_ClientCommand:
+					case ConfigType_ClientCommand:
 					{
 						if (IsClientInGame(vote.Initiator))
 							ClientCommand(vote.Initiator, "%s", g_cfgData[vote.Initiator].cmd);
 					}
-					case Type_CheatCommand:
+					case ConfigType_CheatCommand:
 					{
 						if (!IsClientInGame(vote.Initiator))
 							return;
@@ -278,6 +303,57 @@ void Vote_Handler(L4D2NativeVote vote, VoteAction action, int param1, int param2
 				vote.SetFail();
 		}
 	}
+}
+
+bool StrListContains(char[][] list, int listSize, char[] element)
+{
+	for (int i = 0; i < listSize; i++)
+		if (strlen(list[i]) > 0 && strlen(element) > 0 && strcmp(list[i], element, false) == 0)
+			return true;
+
+	return false;
+}
+
+bool IsValidCustomFlags(char[] flags)
+{
+	TrimString(flags);
+	if (strlen(flags) == 0)
+		return true;
+
+	char menuCustomFlagsList[CUSTOM_FLAG_LIST_MAX_SIZE][CUSTOM_FLAG_MAX_LENGTH];
+	ExplodeString(flags, ",", menuCustomFlagsList, CUSTOM_FLAG_LIST_MAX_SIZE, CUSTOM_FLAG_MAX_LENGTH);
+
+	char cvarCustomFlagsList[CUSTOM_FLAG_LIST_MAX_SIZE][CUSTOM_FLAG_MAX_LENGTH];
+	char cvarCustomFlagsCommaSeparated[128];
+	g_cvMenuCustomFlags.GetString(cvarCustomFlagsCommaSeparated, sizeof(cvarCustomFlagsCommaSeparated));
+	TrimString(cvarCustomFlagsCommaSeparated);
+	ExplodeString(cvarCustomFlagsCommaSeparated, ",", cvarCustomFlagsList, CUSTOM_FLAG_LIST_MAX_SIZE, CUSTOM_FLAG_MAX_LENGTH);
+
+	bool isValid = false;
+	for (int i = 0; i < CUSTOM_FLAG_LIST_MAX_SIZE; i++)
+		isValid |= StrListContains(menuCustomFlagsList, CUSTOM_FLAG_LIST_MAX_SIZE, cvarCustomFlagsList[i]);
+
+	return isValid;
+}
+
+bool IsValidModeFlags(int flags)
+{
+	if (L4D_IsCoopMode() && (flags & MODEFLAGS_COOP))
+		return true;
+
+	if (L4D2_IsRealismMode() && (flags & MODEFLAGS_REALISM))
+		return true;
+
+	if (L4D_IsVersusMode() && (flags & MODEFLAGS_VERSUS))
+		return true;
+
+	if (L4D_IsSurvivalMode() && (flags & MODEFLAGS_SURVIVAL))
+		return true;
+
+	if (L4D2_IsScavengeMode() && (flags & MODEFLAGS_SCAVENGE))
+		return true;
+
+	return false;
 }
 
 bool IsValidTeamFlags(int client, int flags)
@@ -312,18 +388,18 @@ ConfigType GetConfigType(SourceKeyValues kv)
 	kv.GetString("Type", type, sizeof(type));
 
 	if (!strcmp(type, "ServerCommand", false))
-		return Type_ServerCommand;
+		return ConfigType_ServerCommand;
 
 	if (!strcmp(type, "ClientCommand", false))
-		return Type_ClientCommand;
+		return ConfigType_ClientCommand;
 
 	if (!strcmp(type, "ExternalVote", false))
-		return Type_ExternalVote;
+		return ConfigType_ExternalVote;
 
 	if (!strcmp(type, "CheatCommand", false))
-		return Type_CheatCommand;
-	
-	return Type_NotFound;
+		return ConfigType_CheatCommand;
+
+	return ConfigType_NotFound;
 }
 
 void RegAdminCmdEx(const char[] cmd, ConCmd callback, int adminflags, const char[] description="", const char[] group="", int flags=0)

--- a/scripting/l4d2_config_vote.sp
+++ b/scripting/l4d2_config_vote.sp
@@ -38,7 +38,7 @@ SourceKeyValues
 	g_kvSelect[MAXPLAYERS+1],
 	g_kvRoot;
 
-ConVar g_cvVoteFilePath, g_cvAdminTeamFlags, g_cvPrintMsg;
+ConVar g_cvVoteFilePath, g_cvAdminTeamFlags, g_cvPrintMsg, g_cvPassMode;
 ConfigData g_cfgData[MAXPLAYERS+1];
 
 public Plugin myinfo = 
@@ -60,6 +60,7 @@ public void OnPluginStart()
 	g_cvVoteFilePath = CreateConVar("l4d2_config_vote_path", "data/l4d2_config_vote.kv", "Vote config file path.");
 	g_cvAdminTeamFlags = CreateConVar("l4d2_config_vote_adminteamflags", "1", "Admin bypass TeamFlags.");
 	g_cvPrintMsg = CreateConVar("l4d2_config_vote_printmsg", "1", "Whether print hint message to clients.");
+	g_cvPassMode = CreateConVar("l4d2_config_vote_passmode", "1", "Method of judging vote pass. 0=Vote Yes count > Vote No count. 1=Vote Yes count > Half of players count.");
 	g_cvVoteFilePath.AddChangeHook(OnCvarChanged);
 	// AutoExecConfig(true, "l4d2_config_vote");
 }
@@ -237,7 +238,8 @@ void Vote_Handler(L4D2NativeVote vote, VoteAction action, int param1, int param2
 		}
 		case VoteAction_End:
 		{
-			if (vote.YesCount > vote.NoCount)
+			bool voteResult = (g_cvPassMode.BoolValue) ? (vote.YesCount > vote.PlayerCount / 2) : (vote.YesCount > vote.NoCount);
+			if (voteResult)
 			{
 				vote.SetPass("加载中...");
 

--- a/scripting/l4d2_config_vote.sp
+++ b/scripting/l4d2_config_vote.sp
@@ -237,7 +237,7 @@ void Vote_Handler(L4D2NativeVote vote, VoteAction action, int param1, int param2
 		}
 		case VoteAction_End:
 		{
-			if (vote.YesCount > vote.PlayerCount/2)
+			if (vote.YesCount > vote.NoCount)
 			{
 				vote.SetPass("加载中...");
 


### PR DESCRIPTION
### Feature 1: Added 'MenuModeFlags'
Added new tag 'MenuModeFlags', related to gamemodes.  
Defines whether clients can see the menu and initiate a vote in these gamemodes (based on). coop=1, realism=2, versus=4, survival=8, scavenge=16, default value: 31 (all gamemodes).  
*Note: Mutations are also based on these fundamental gamemodes.*  
  
![image](https://github.com/user-attachments/assets/7fb26c95-2af7-4caf-a20f-d522199b23ad)  
![image](https://github.com/user-attachments/assets/ef81d218-cac1-42bd-a4af-935160bd34db)  
![image](https://github.com/user-attachments/assets/14580068-4b40-4f4c-89a4-3fde9e366bcc)  
  
### Feature 2: Added 'MenuCustomFlags'
If the existing Flag tag still can not meet your needs, you can set your own custom flags for whether showing the vote config or not.  
It needs to work with a new cvar `l4d2_config_vote_menucustomflags`.  
#### Description
The value of `MenuCustomFlags` in the config menu can be set to a comma separated string. For example: "custom1", or "custom1,custom2".  
The value of the plugin cvar `l4d2_config_vote_menucustomflags` can also be set to a comma separated string. For example: "custom1", or "custom1,custom2".  
**If the `MenuCustomFlags` value is "&lt;Empty String&gt; (Not Configured)", then there will be no limits.**  
**If the `MenuCustomFlags` value is configured, then only if the `MenuCustomFlags` and the `l4d2_config_vote_menucustomflags` have some elements in common (the intersection of the `MenuCustomFlags` and the `l4d2_config_vote_menucustomflags` is not empty), this config in the menu can be shown to clients.**  
> Example:  
>     1. `MenuCustomFlags`: "(Not Configured)", no matter what the cvar `l4d2_config_vote_menucustomflags` value is. =&gt; Clients **can see** this vote config in menu.  
>     2. `MenuCustomFlags`: "1", `l4d2_config_vote_menucustomflags`: "1". =&gt; Clients **can see** this vote config in menu.  
>     3. `MenuCustomFlags`: "2", `l4d2_config_vote_menucustomflags`: "1". =&gt; Clients **can not see** this vote config in menu.  
>     4. `MenuCustomFlags`: "1,2", `l4d2_config_vote_menucustomflags`: "1". =&gt; Clients **can see** this vote config in menu.  
>     5. `MenuCustomFlags`: "1,2", `l4d2_config_vote_menucustomflags`: "3". =&gt; Clients **can not see** this vote config in menu.  
>     6. `MenuCustomFlags`: "1", `l4d2_config_vote_menucustomflags`: "1,2". =&gt; Clients **can see** this vote config in menu.  
>     7. `MenuCustomFlags`: "3", `l4d2_config_vote_menucustomflags`: "1,2". =&gt; Clients **can not see** this vote config in menu.  
>     8. `MenuCustomFlags`: "1,2", `l4d2_config_vote_menucustomflags`: "2,3". =&gt; Clients **can see** this vote config in menu.  
  
![image](https://github.com/user-attachments/assets/de548ec0-436a-4d66-85db-0e0182034a44)  
![image](https://github.com/user-attachments/assets/35f99a22-3402-4462-a899-c9ad2a84493e)  
![image](https://github.com/user-attachments/assets/b52979b1-1141-4b7e-a3ab-1f8a7615d72b)  
![image](https://github.com/user-attachments/assets/13ded495-148d-481c-bc00-e0d92c3075cb)  
  
### Feature 3: Vote configs can show selected/unselected icon
Added the function of displaying a selected/unselected icon.  
Default Selected Icon: `[√]`  
Default Unselected Icon: `[  ]`  

#### SelectType (Optional)
If this property is set on one node, then all of it's first level sub nodes will show a selected icon.  
- `Single`：If one config's vote is passed, this node's icon will be set to selected, and all the other same level nodes' icon will be set to unselected.  
- `Multiple`：If one config's vote is passed, this node's icon will be set to it's opposite.  
- `CvarTracking`：Whether showing the selected icon depends on a specified cvar value.  
- `PluginTracking`：Whether showing the selected icon depends on whether a specified plugin is loaded.  
  
#### Selected (Optional)
This property is valid only when **parent level** node's SelectType is specified to `Single` or `Multiple`.  
Marking this node as default selected.  
  
#### CvarName (Optional)
This property is valid only when **this level** node's SelectType is specified to `CvarTracking`.  
Specifying the cvar name to track.  
  
#### CvarType (Optional)
This property is valid only when **this level** node's SelectType is specified to `CvarTracking`.  
Specifying the cvar value datatype.  
- `int`：Indicate the cvar value is a int type.  
- `float`：Indicate the cvar value is a float type.  
- `string`：Indicate the cvar value is a string type.  
  
#### CvarMatch (Optional)
This property is valid only when **parent level** node's SelectType is specified to `CvarTracking`, and **parent level** node's CvarName and CvarType are specified correctly.  
Specifying the voting config value, which matches the specified cvar value, used to show a selected icon.  
  
#### PluginMatch (Optional)
This property is valid only when **parent level** node's SelectType is specified to `PluginTracking`.  
Specifying the voting config to load/unload the specified plugin, which matches the specified plugin name, used to show a selected icon.  
  
![image](https://github.com/user-attachments/assets/13192a92-3b4a-4a65-88ca-16b1ecdfd81f)  
![image](https://github.com/user-attachments/assets/b52632c1-35f6-49c6-a9ba-2dcc0b735950)  
![image](https://github.com/user-attachments/assets/e7ed18a5-c7ca-40d6-a078-fd76f31dc890)  
  
Finally, Happy New Year, fdxx!  
